### PR TITLE
Shows a placeholder when there are no upcoming meetups

### DIFF
--- a/webpack/components/meetup.js
+++ b/webpack/components/meetup.js
@@ -40,7 +40,7 @@ export function hideDefaultMeetup() {
 
 export function startMeetupWidget(callback) {
   meetup.getNextMeetup(function(err, result) {
-    if(!err) {
+    if(!err && Array.isArray(result) && result.length > 0) {
       meetup.renderNextMeetup(result);
       return callback();
     }

--- a/webpack/components/meetup.test.js
+++ b/webpack/components/meetup.test.js
@@ -1,14 +1,27 @@
 import * as meetup from './meetup.js';
 
 describe('startMeetupWidget',  () => {
+
+  beforeEach(() => {
+    jest.spyOn(meetup, 'getNextMeetup');
+    jest.spyOn(meetup, 'renderNextMeetup');
+    jest.spyOn(meetup, 'renderNoneMeetup');
+  });
+
+  afterEach(() => {
+    meetup.getNextMeetup.mockRestore();
+    meetup.renderNextMeetup.mockRestore();
+    meetup.renderNoneMeetup.mockRestore();
+  });
+
   test('renders a meetup when one exists', (done) => {
     const MOCK_RESULT = [
       {mock_result: true}
     ];
 
-    jest.spyOn(meetup, 'getNextMeetup').mockImplementation((callback) => {return callback(null, MOCK_RESULT)});
-    jest.spyOn(meetup, 'renderNextMeetup').mockImplementation(() => {return});
-    jest.spyOn(meetup, 'renderNoneMeetup').mockImplementation(() => {return});
+    meetup.getNextMeetup.mockImplementation((callback) => {return callback(null, MOCK_RESULT)});
+    meetup.renderNextMeetup.mockImplementation(() => {});
+    meetup.renderNoneMeetup.mockImplementation(() => {});
 
     meetup.startMeetupWidget((err) => {
       if(err) {
@@ -18,6 +31,42 @@ describe('startMeetupWidget',  () => {
       expect(meetup.getNextMeetup).toHaveBeenCalled();
       expect(meetup.renderNextMeetup).toHaveBeenCalledWith(MOCK_RESULT);
       expect(meetup.renderNoneMeetup).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  test('renders a placeholder when an error occurs', (done) => {
+    meetup.getNextMeetup.mockImplementation((callback) => {return callback(new Error('Test Error'))});
+    meetup.renderNextMeetup.mockImplementation(() => {});
+    meetup.renderNoneMeetup.mockImplementation(() => {});
+
+    meetup.startMeetupWidget((err) => {
+      if(err) {
+        done(err);
+      }
+
+      expect(meetup.getNextMeetup).toHaveBeenCalled();
+      expect(meetup.renderNextMeetup).not.toHaveBeenCalled();
+      expect(meetup.renderNoneMeetup).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  test('renders a placeholder when no meetups exist', (done) => {
+    const MOCK_RESULT = [];
+
+    meetup.getNextMeetup.mockImplementation((callback) => {return callback(null, MOCK_RESULT)});
+    meetup.renderNextMeetup.mockImplementation(() => {});
+    meetup.renderNoneMeetup.mockImplementation(() => {});
+
+    meetup.startMeetupWidget((err) => {
+      if(err) {
+        done(err);
+      }
+
+      expect(meetup.getNextMeetup).toHaveBeenCalled();
+      expect(meetup.renderNextMeetup).not.toHaveBeenCalled();
+      expect(meetup.renderNoneMeetup).toHaveBeenCalled();
       done();
     });
   });


### PR DESCRIPTION
Fixes an issue where the loading spinner was infinitely shown when the meetup API returned 0 results. 

Changes: 
- The next meetup rendering code is now only triggered when no XHR errors occur and there are results to show.
- The placeholder is shown in all other scenarios. 

Fixes #1 